### PR TITLE
Release 1.1.1

### DIFF
--- a/content/post/release-of-1.1.1.md
+++ b/content/post/release-of-1.1.1.md
@@ -1,0 +1,25 @@
+---
+date: "2017-05-04T17:20:00+02:00"
+author: "bkcsoft"
+title: "Release of 1.1.1"
+tags: ["release"]
+draft: false
+---
+
+We proudly present the bugfix release of Gitea version 1.1.1. We have merged [10](https://github.com/go-gitea/gitea/milestone/10?closed=1) pull requests to release this version of Gitea. You can download one of our pre-built binaries from our [downloads page](https://dl.gitea.io/gitea/1.1.1/), you just need to select the correct platform. For further details of the installation follow our [installation guide](https://docs.gitea.io/en-us/install-from-binary/).
+
+<!--more-->
+
+## Changelog
+
+* BUGFIXES
+  * Markdown Sanitation Fix [#1646](https://github.com/go-gitea/gitea/pull/1646)
+  * Fix broken hooks [#1376](https://github.com/go-gitea/gitea/pull/1376)
+  * Fix migration issue [#1375](https://github.com/go-gitea/gitea/pull/1375)
+  * Fix Wiki Issues [#1338](https://github.com/go-gitea/gitea/pull/1338)
+  * Forgotten migration for wiki githooks [#1237](https://github.com/go-gitea/gitea/pull/1237)
+  * Commit messages can contain pipes [#1218](https://github.com/go-gitea/gitea/pull/1218)
+  * Verify external tracker URLs [#1236](https://github.com/go-gitea/gitea/pull/1236)
+  * Allow upgrade after downgrade [#1197](https://github.com/go-gitea/gitea/pull/1197)
+  * 500 on delete repo with issue [#1195](https://github.com/go-gitea/gitea/pull/1195)
+  * INI compat with CrowdIn [#1192](https://github.com/go-gitea/gitea/pull/1192)


### PR DESCRIPTION
Blocked by https://github.com/go-gitea/gitea/pull/1672 and actually tagging the release.