### PR TITLE
Change site title to make RSS feed title more descriptive

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 baseurl: https://blog.gitea.io/
 languageCode: en-us
-title: Blog
+title: Gitea Blog
 theme: gitea
 disqusShortname: gitea
 


### PR DESCRIPTION
This also changes the title of the site shown across all pages, which
is beneficial for similar reasons. Changing the feed alone would
involve a custom template for the feed, which would be too much.

Originally suggested in #40.

Signed-off-by: Bill Lovett <bill@ilovett.com>
